### PR TITLE
fix: remove metrics_generator_enabled flag

### DIFF
--- a/tempo/rootfs/etc/tempo/local-config.yaml
+++ b/tempo/rootfs/etc/tempo/local-config.yaml
@@ -1,6 +1,5 @@
 ---
 target: all
-metrics_generator_enabled: true
 search_enabled: true
 
 server:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the system configuration by removing the explicit metrics activation setting while maintaining other key settings intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->